### PR TITLE
Restore old column initialization for column

### DIFF
--- a/lib/sortable.rb
+++ b/lib/sortable.rb
@@ -22,7 +22,7 @@ module Sortable
     attr_reader :name, :column, :scope, :method
     def initialize(name, scope = nil, column: name, method: nil)
       @name = name
-      @column = [*column]
+      @column = column
       @method = method
       @scope = scope
     end


### PR DESCRIPTION
Restore last change. After last commit the gem stopped to work. Its sending something like:

ORDER BY \"[column]\" ASC

instead should be

ORDER BY column ASC